### PR TITLE
Resolve predictions having negative numbers This bugfix solves the is…

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -174,7 +174,7 @@ app.post(
 app.get(
 	"/prediction",
 	(req,res) => {
-		const resturaunt = req.query.resturant; 
+		const resturaunt = req.body.resturant; 
 		// sanity check time, we want to ensure these are valid inputs
 		if(RESTURAUNTCODES.findIndex((val) => val === resturaunt) === -1){
 			res.json({
@@ -194,7 +194,7 @@ app.get(
 app.get(
 	"/waitTime",
 	(req,res) => {
-		const resturaunt = req.query.resturaunt; 
+		const resturaunt = req.body.resturaunt; 
 		// sanity check time, we want to ensure these are valid inputs
 		if(RESTURAUNTCODES.findIndex((val) => val === resturaunt) === -1){
 			res.json({
@@ -254,7 +254,7 @@ secureRoots.post(
     '/recordTime',
     async (req,res,next) => {
 		// get our field inputs
-		const restauraunt = req.body.resturant; // which resturant the user was waiting for
+		const restauraunt = req.body.restaurant; // which resturant the user was waiting for
 		const timeDuration = +req.body.timeDuration; // how long they waited in seconds(can be changed to millis later)
 		// sanity check time, we want to ensure these are valid inputs
 		if(RESTURAUNTCODES.findIndex((val) => val === restauraunt) === -1){

--- a/server/models/models.js
+++ b/server/models/models.js
@@ -120,14 +120,12 @@ PredictionSchema.methods.integrateValues = function(points){
 }
 
 PredictionSchema.methods.generatePrediction = function(points){
-	let d = new Date();
-	let dayStart = new Date(d.getFullYear(),d.getMonth(),d.getDate(),0,0,0,0);
 	let predictionList = [];
 	// populate the list with the current values of the day
 	for(let i in points){
 		if(points[i].elements.length > 0)
 			predictionList.push([
-				points[i].time - dayStart,
+				points[i].time,
 				points[i].total/points[i].elements.length,
 			]);
 	}


### PR DESCRIPTION
…sue where predictions would have negative numbers. This is because I accidentally subtracted the start-of-day timestamp twice. This commit also moves some endpoints that used params to use a body to be like our other requests.