### PR TITLE
Change Gets to use parameters instead of a body

### DIFF
--- a/server/helpers/restaurant.js
+++ b/server/helpers/restaurant.js
@@ -25,7 +25,7 @@ exports.createRestaurant = async function (req, res, next) {
 };
 
 exports.getRestaurantProfile = async function (req, res, next) {
-  let { name } = req.body;
+  let { name } = req.query;
  
   let restaurant = await restaurantModel.findOne({ name: name });
 


### PR DESCRIPTION
Most browsers don't support using a body in a get request as this was only recently allowed by the http spec. As a result, we need to change these to use the standard parameters to maintain frontend usability